### PR TITLE
Allow this crate to be used in `no_std` context

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,38 @@
+#![no_std]
+
+extern crate alloc;
+
+#[doc(hidden)]
+pub use alloc::string::String;
+
 #[macro_export]
 macro_rules! string_concat {
-    ( $( $x:expr ),* ) => {
-        {
-            let mut temp_string = String::new();
-            $(
-                temp_string.push_str($x);
-            )*
-            temp_string
-        }
+    ( $( $x:expr ),* ) => {{
+        $crate::string_concat_impl!{[] $($x),*}
+    }};
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! string_concat_impl {
+    ([$($x:ident)*] ) => {{
+        let mut temp_string = $crate::String::with_capacity(0$(+$x.len())*);
+        $(
+            temp_string.push_str($x);
+        )*
+        temp_string
+    }};
+    ([$($ident:ident)*] $x:expr $(, $rest:expr)*) => {
+        let ref x = $x;
+        string_concat_impl!{[$($ident)* x] $($rest),*}
     };
 }
 
 #[cfg(test)]
 mod tests {
-    extern crate alloc;
+    use alloc::string::ToString;
+    use crate::String;
+    
     #[test]
     fn it_works() {
         let s: String = string_concat!("hello");
@@ -28,7 +47,7 @@ mod tests {
 
     #[test]
     fn it_works_with_vars() {
-        let name = "richard";
+        let name = "richard".to_string();
         let s: String = string_concat!("hello ", name, "!");
         assert_eq!(s, "hello richard!");
     }


### PR DESCRIPTION
This allows this crate to be used in a `no_std` context, and enables you to transparently use `String` an as argument without consuming it.